### PR TITLE
fixed test for destroying a Model

### DIFF
--- a/test/test.model.js
+++ b/test/test.model.js
@@ -64,6 +64,7 @@ describe('#Model', function() {
       }});
     }});
   });
+
   it('Should create empty model and accept variables in .save', function(t) {
     var m = new MyModel();
     m.save({id:123}).then(function() {
@@ -73,18 +74,19 @@ describe('#Model', function() {
       assert.ok(false)
     });
   });
+
   it('Should be destroyable.', function(t) {
     var m = new MyModel();
     m.save({id:123,asd:"asd"}).then(function() {
       assert.equal(m.get("id"), 123);
-      m.fetch().then(function() {
-        assert.ok(false);
+      m.destroy().then(function() {
+        t();
       }).otherwise(function() {
-          t();
-      });
+        assert.ok(false);
+      }).otherwise(t);
     }, function() {
-      assert.ok(false)
-    });
+      assert.ok(false);
+    }).otherwise(t);
   });
 
   it('Should reject .save() promise on failed validation', function(done) {


### PR DESCRIPTION
There was no valid test for destroy functionality. Fixed the test, but Model.destroy seems to be failing due to Backbone.Db.sync returns an error.
